### PR TITLE
Test

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+    <!--テスト用-->
     <%= render "layouts/header" %>
     <%= render "layouts/flash" %>
     <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,7 @@
   </head>
 
   <body>
-<<<<<<< HEAD
     <!--テスト用-->
-=======
-    # コメント追加
-    # コメント追加2
-    # ブランチtest
->>>>>>> main
     <%= render "layouts/header" %>
     <%= render "layouts/flash" %>
     <%= yield %>


### PR DESCRIPTION
## 何を実現するための PR か？

item_categoryの追加 2(#14)を実現するため。
#10 で追加したitem_categoryをitemに紐付けできるようにするため。

### 外部 URL
issue ：[item_categoryの追加 2課題の詳細](https://github.com/asaburo/furoshiki_maeda/issues/14#issue-1080728868)
slack ：[item_categoryの追加 2課題に関するやり取り](https://asaubro.slack.com/archives/C02P5MDL7HD/p1639558016002300)

## 実装内容
### カラムの追加
- Itemモデルに、item_category_idカラム（integer）を追加。

### 利用者側
- ユーザーmypageのitemフォームでitem_categoryをセレクトボックスから選択 & 保存を可能にした。

### 管理者側
- 管理画面 item_categoryの削除は Itemが一つでも紐付いていたら削除できないようにした。（punditのpolisyを編集し、実装）

## 考えられる影響範囲
- Itemに、item_category_idカラムを追加し、バリデーション（presence: true）を設定しているため、新たにItemを作成する場合はitem_category_idカラムが必須となる。

- config/locales/models/item.ja.ymlに、item_category_id："カテゴリー"を追加したため、item.ja.ymlの呼び出し時に、注意が必要。

## 実装者目線で特に重点的にレビューしてほしい所

1. punditのpolicyを使用した、Itemのdestroyアクションを制限するロジックは適切か。
```
def destroy?
  record.items.blank?
end
```
## UI の変更

1. アイテム登録フォーム・エラーメッセージ
【変更前】
<img width="1680" alt="スクリーンショット 2021-12-18 21 04 00" src="https://user-images.githubusercontent.com/75834810/146640326-f195208d-2221-4b07-8455-3527c3ce3fe7.png">

【変更後】
<img width="1679" alt="スクリーンショット 2021-12-18 21 02 19" src="https://user-images.githubusercontent.com/75834810/146640359-f3503346-504b-4bcd-ada1-376fc1992527.png">

2. アイテム詳細画面
【変更前】
<img width="1679" alt="スクリーンショット 2021-12-18 21 07 25" src="https://user-images.githubusercontent.com/75834810/146640399-014fc6d9-d4ff-4d6f-bf27-58c08873bda0.png">

【変更後】
<img width="1679" alt="スクリーンショット 2021-12-18 21 07 01" src="https://user-images.githubusercontent.com/75834810/146640401-bf0cf181-ec65-4788-a78c-fcad1db1c3af.png">

## レビュー期限

なし

## 動作確認リスト
【利用者側】
1. アイテムフォームより、任意のカテゴリーを選択し、アイテムを登録。
2. アイテム詳細に遷移し、選択したカテゴリーが表示されることを確認。

【管理者側】
1. アイテムカテゴリー一覧ページを表示。
2. 利用者側で選択したカテゴリーの、詳細ボタンをクリック。
3. 右上に削除ボタンが、表示されないことを確認。
4. アイテムカテゴリー登録画面より、新規カテゴリーを追加。
5. 新規登録したアイテムカテゴリーの詳細画面に移動。
6. 右上に削除ボタンが表示されることを確認。
※ItemCategoryPolicyを使用し、紐づいたItemがある場合、ない場合で上記のように、表示非表示を切り替えている。（3:表示、6:非表示）